### PR TITLE
不具合修正・追加実装

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -136,19 +136,30 @@ public class StockController {
 
     @GetMapping("/stock/calendar")
     public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
-
-        LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
-        Integer targetYear = year == null ? today.getYear() : year;
-        Integer targetMonth = today.getMonthValue();
-
-        LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
+        // リクエストパラメータがnullの場合、現在の年月を使用する
+        if (year == null || month == null) {
+                LocalDate today = LocalDate.now();
+                year = today.getYear();
+                month = today.getMonthValue();
+        }
+            
+        // 月の増減の条件分岐を修正
+        if (month < 1) {
+            month = 12; // 12月に設定
+            year--; // 前年にする
+        } else if (month > 12) {
+            month = 1; // 1月に設定
+            year++; // 翌年にする
+        }
+        
+        LocalDate startDate = LocalDate.of(year, month, 1);
         Integer daysInMonth = startDate.lengthOfMonth();
 
-        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<List<CalendarDto>> stocksLists = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(year, month, startDate, daysInMonth);
+        List<List<CalendarDto>> stocksLists = this.stockService.generateValues(year, month, daysInMonth);
 
-        model.addAttribute("targetYear", targetYear);
-        model.addAttribute("targetMonth", targetMonth); 
+        model.addAttribute("targetYear", year);
+        model.addAttribute("targetMonth", month); 
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
 

--- a/src/main/resources/static/css/stock/calendar.css
+++ b/src/main/resources/static/css/stock/calendar.css
@@ -23,7 +23,7 @@
 }
 
 #calendar_table tr th {
-    background-color: #E1E1E2;
+    background-color: #ffffff;
     width: 100%;
 }
 
@@ -38,4 +38,25 @@
 
 .no-underline {
     text-decoration: none; /* リンクの下線を消す */
+}
+
+.saturday {
+    color: blue;
+}
+
+.sunday {
+    color: red;
+}
+
+#calendar_table tr:nth-child(odd) {
+    background-color: #e7e5e5e7; /* グレー色 */ 
+}
+
+#calendar_table tr:nth-child(even) {
+    background-color: #FFFFFF; /* 白色 */
+}
+
+.header_book {
+    text-align: left;
+    vertical-align: bottom;
 }

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -31,7 +31,7 @@
                                 <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
-                                <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
+                                <th th:each="day : ${daysOfWeek}" th:text="${day}" th:classappend="${day.contains('土')} ? 'saturday' : (${day.contains('日')} ? 'sunday' : '')"></th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
・カレンダーの土日のテキストカラー変更
　(土曜日：青、日曜日：赤)

・2024年1月の状態で「前月」を押下した時と、2024年12月の状態で「翌月」を押下した時に、画面上にエラーが表示されてしまったため修正

・CSSを修正し、基本設計通りの見た目に修正
　(ラベル部分：グレー→白、テーブル部分：白→グレー・白交互になるように)
